### PR TITLE
= 1.9.3 =

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,11 @@ WooCommerce plugin to use Sellix as a Payment Gateway.
 - Removed payment gateway selection.
 - Removed confirmations settings
 - Updated logo dimensions.
+
+= 1.9.2 =
+- Fixed logo image missing
+
+= 1.9.3 =
+- Added a new option: If merchant have more than one shop under their Sellix account, send API requests with their authorization by passing the X-Sellix-Merchant header to each request.
+- Plugin tested on WordPress 6.2.1
+- Plugin tested on WooCommerce 7.5.1

--- a/sellix-pay/readme.txt
+++ b/sellix-pay/readme.txt
@@ -106,3 +106,11 @@ It’s simple. Tap on the “Sign Up” button on the top and start transferring
 - Removed payment gateway selection.
 - Removed confirmations settings
 - Updated logo dimensions.
+
+= 1.9.2 =
+- Fixed logo image missing
+
+= 1.9.3 =
+- Added a new option: If merchant have more than one shop under their Sellix account, send API requests with their authorization by passing the X-Sellix-Merchant header to each request.
+- Plugin tested on WordPress 6.2.1
+- Plugin tested on WooCommerce 7.5.1


### PR DESCRIPTION
- Added a new option: If merchant have more than one shop under their Sellix account, send API requests with their authorization by passing the X-Sellix-Merchant header to each request.
- Plugin tested on WordPress 6.2.1
- Plugin tested on WooCommerce 7.5.1